### PR TITLE
对于不能顶功的首选添加提示

### DIFF
--- a/rime/lua/xkjd6_filter.lua
+++ b/rime/lua/xkjd6_filter.lua
@@ -26,10 +26,21 @@ local function danzi(cand)
     return false
 end
 
+local function commit_hint(cand)
+    cand:get_genuine().comment = '🚫' .. cand.comment
+end
+
 local function filter(input, env)
     local is_danzi = env.engine.context:get_option('danzi_mode')
     local is_on = env.engine.context:get_option('sbb_hint')
+    local first = true
+    local input_text = env.engine.context.input
+    local no_commit = input_text:len() < 4 and input_text:match("^[bcdefghjklmnpqrstwxyz]+$")
     for cand in input:iter() do
+        if first and no_commit and cand.type ~= 'completion' then
+            commit_hint(cand)
+        end
+        first = false
         if not is_danzi or danzi(cand) then
             if is_on then
             hint(cand, env.engine.context, env.reverse)


### PR DESCRIPTION
由于目前默认的脚本是 "xkjd6_hint.lua", 这部分拷贝自 "for_hint.lua", 并作如下修改：

1. 只对非 completion 的候选起作用
2. 使用了不同的 emoji 符号，其红色占比较少（虽然在 windows 上的 emoji 是单色的， iOS 上只能显示感叹号）