### PR TITLE
修正「酆」字笔顺

### DIFF
--- a/Tools/TermsTools/cizu.txt
+++ b/Tools/TermsTools/cizu.txt
@@ -29192,9 +29192,9 @@
 福如东海	frdh
 风度	frdj
 峰度	frdji
+酆都	frdjiu
 肥肉大酒	frdju
 封堵	frdjv
-酆都	frdjvu
 封底	frdk
 疯癫	frdm
 风灯	frdr

--- a/Tools/TermsTools/danzi.txt
+++ b/Tools/TermsTools/danzi.txt
@@ -3526,6 +3526,8 @@
 锋	frio
 锋	frioua
 俸	friv
+酆	friva
+酆	frivai
 俸	frivvv
 疯	fro
 讽	froa
@@ -3552,8 +3554,6 @@
 砜	frvuu
 砜	frvuua
 奉	frvv
-酆	frvva
-酆	frvvai
 丰	frvvvi
 奉	frvvvv
 发	fs

--- a/Tools/TermsTools/xkjd6.cizu.dict.yaml
+++ b/Tools/TermsTools/xkjd6.cizu.dict.yaml
@@ -29197,9 +29197,9 @@ sort: original
 福如东海	frdh
 风度	frdj
 峰度	frdji
+酆都	frdjiu
 肥肉大酒	frdju
 封堵	frdjv
-酆都	frdjvu
 封底	frdk
 疯癫	frdm
 风灯	frdr

--- a/Tools/TermsTools/xkjd6.danzi.dict.yaml
+++ b/Tools/TermsTools/xkjd6.danzi.dict.yaml
@@ -3531,6 +3531,8 @@ sort: original
 锋	frio
 锋	frioua
 俸	friv
+酆	friva
+酆	frivai
 俸	frivvv
 疯	fro
 讽	froa
@@ -3557,8 +3559,6 @@ sort: original
 砜	frvuu
 砜	frvuua
 奉	frvv
-酆	frvva
-酆	frvvai
 丰	frvvvi
 奉	frvvvv
 发	fs

--- a/Tools/TermsTools/xkjd6.dict.yaml
+++ b/Tools/TermsTools/xkjd6.dict.yaml
@@ -1808,6 +1808,7 @@ sort: original
 葑	frii
 锋	frio
 俸	friv
+酆	friva
 疯	fro
 讽	froa
 烽	frou
@@ -1821,7 +1822,6 @@ sort: original
 枫	frvu
 砜	frvuu
 奉	frvv
-酆	frvva
 发	fs
 法	fsa
 溠	fsao
@@ -10696,6 +10696,7 @@ sort: original
 崶	friavo
 葑	friivo
 锋	frioua
+酆	frivai
 俸	frivvv
 讽	froaua
 烽	frouua
@@ -10709,7 +10710,6 @@ sort: original
 堼	frvovo
 枫	frvuau
 砜	frvuua
-酆	frvvai
 丰	frvvvi
 奉	frvvvv
 溠	fsaouv
@@ -45738,9 +45738,9 @@ sort: original
 峰顶	frdgi
 福如东海	frdh
 风度	frdj
+酆都	frdjiu
 肥肉大酒	frdju
 封堵	frdjv
-酆都	frdjvv
 封底	frdk
 疯癫	frdm
 风灯	frdr

--- a/rime/xkjd6.cizu.dict.yaml
+++ b/rime/xkjd6.cizu.dict.yaml
@@ -29197,9 +29197,9 @@ sort: original
 福如东海	frdh
 风度	frdj
 峰度	frdji
+酆都	frdjiu
 肥肉大酒	frdju
 封堵	frdjv
-酆都	frdjvu
 封底	frdk
 疯癫	frdm
 风灯	frdr

--- a/rime/xkjd6.danzi.dict.yaml
+++ b/rime/xkjd6.danzi.dict.yaml
@@ -3531,6 +3531,8 @@ sort: original
 锋	frio
 锋	frioua
 俸	friv
+酆	friva
+酆	frivai
 俸	frivvv
 疯	fro
 讽	froa
@@ -3557,8 +3559,6 @@ sort: original
 砜	frvuu
 砜	frvuua
 奉	frvv
-酆	frvva
-酆	frvvai
 丰	frvvvi
 奉	frvvvv
 发	fs

--- a/rime/xkjd6cx.dict.yaml
+++ b/rime/xkjd6cx.dict.yaml
@@ -3440,6 +3440,8 @@ sort: original
 锋	frio
 锋	frioua
 俸	friv
+酆	friva
+酆	frivai
 俸	frivvv
 疯	fro
 讽	froa
@@ -3466,8 +3468,6 @@ sort: original
 砜	frvuu
 砜	frvuua
 奉	frvv
-酆	frvva
-酆	frvvai
 丰	frvvvi
 奉	frvvvv
 发	fs

--- a/rime/xkjd6dz.dict.yaml
+++ b/rime/xkjd6dz.dict.yaml
@@ -3440,6 +3440,8 @@ sort: original
 锋	frio
 锋	frioua
 俸	friv
+酆	friva
+酆	frivai
 俸	frivvv
 疯	fro
 讽	froa
@@ -3466,8 +3468,6 @@ sort: original
 砜	frvuu
 砜	frvuua
 奉	frvv
-酆	frvva
-酆	frvvai
 丰	frvvvi
 奉	frvvvv
 发	fs


### PR DESCRIPTION
根据「酆」字笔顺，「豐」的上部应先写「山」的中间一竖，然后是左右的「丰」，接着是「山」余下的折和竖。