### PR TITLE
补全「尺」的读音

### DIFF
--- a/Tools/TermsTools/danzi.txt
+++ b/Tools/TermsTools/danzi.txt
@@ -5819,7 +5819,9 @@
 戒	jdvvui
 车	je
 澈	jea
+尺	jeav
 澈	jeaova
+尺	jeavuo
 撤	jei
 扯	jeiu
 扯	jeiuiv
@@ -13266,7 +13268,9 @@
 椆	wdvuav
 车	we
 澈	wea
+尺	weav
 澈	weaova
+尺	weavuo
 撤	wei
 扯	weiu
 扯	weiuiv

--- a/Tools/TermsTools/xkjd6.danzi.dict.yaml
+++ b/Tools/TermsTools/xkjd6.danzi.dict.yaml
@@ -5824,7 +5824,9 @@ sort: original
 戒	jdvvui
 车	je
 澈	jea
+尺	jeav
 澈	jeaova
+尺	jeavuo
 撤	jei
 扯	jeiu
 扯	jeiuiv
@@ -13271,7 +13273,9 @@ sort: original
 椆	wdvuav
 车	we
 澈	wea
+尺	weav
 澈	weaova
+尺	weavuo
 撤	wei
 扯	weiu
 扯	weiuiv

--- a/Tools/TermsTools/xkjd6.dict.yaml
+++ b/Tools/TermsTools/xkjd6.dict.yaml
@@ -2975,6 +2975,7 @@ sort: original
 桔	jdvvo
 车	je
 澈	jea
+尺	jeav
 撤	jei
 扯	jeiu
 㬚	jeo
@@ -6791,6 +6792,7 @@ sort: original
 椆	wdvu
 车	we
 澈	wea
+尺	weav
 撤	wei
 扯	weiu
 㬚	weo
@@ -11865,6 +11867,7 @@ sort: original
 桔	jdvvoo
 戒	jdvvui
 澈	jeaova
+尺	jeavuo
 扯	jeiuiv
 撤	jeiuov
 㬚	jeoiov
@@ -15683,6 +15686,7 @@ sort: original
 酬	wdviou
 椆	wdvuav
 澈	weaova
+尺	weavuo
 扯	weiuiv
 撤	weiuov
 㬚	weoiov

--- a/rime/xkjd6.danzi.dict.yaml
+++ b/rime/xkjd6.danzi.dict.yaml
@@ -5824,7 +5824,9 @@ sort: original
 戒	jdvvui
 车	je
 澈	jea
+尺	jeav
 澈	jeaova
+尺	jeavuo
 撤	jei
 扯	jeiu
 扯	jeiuiv
@@ -13271,7 +13273,9 @@ sort: original
 椆	wdvuav
 车	we
 澈	wea
+尺	weav
 澈	weaova
+尺	weavuo
 撤	wei
 扯	weiu
 扯	weiuiv

--- a/rime/xkjd6cx.dict.yaml
+++ b/rime/xkjd6cx.dict.yaml
@@ -5621,7 +5621,9 @@ sort: original
 戒	jdvvui
 车	je
 澈	jea
+尺	jeav
 澈	jeaova
+尺	jeavuo
 撤	jei
 扯	jeiu
 扯	jeiuiv
@@ -12964,7 +12966,9 @@ sort: original
 梼	wdvvvu
 车	we
 澈	wea
+尺	weav
 澈	weaova
+尺	weavuo
 撤	wei
 扯	weiu
 扯	weiuiv

--- a/rime/xkjd6dz.dict.yaml
+++ b/rime/xkjd6dz.dict.yaml
@@ -5621,7 +5621,9 @@ sort: original
 戒	jdvvui
 车	je
 澈	jea
+尺	jeav
 澈	jeaova
+尺	jeavuo
 撤	jei
 扯	jeiu
 扯	jeiuiv
@@ -12964,7 +12966,9 @@ sort: original
 梼	wdvvvu
 车	we
 澈	wea
+尺	weav
 澈	weaova
+尺	weavuo
 撤	wei
 扯	weiu
 扯	weiuiv


### PR DESCRIPTION
「工尺」中，「尺」读作 chě，但词库未收录。这个 commit 给单字加上了这个读音。