### PR TITLE
自动同步至 Gitee

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,19 @@
+name: Mirror Github to Gitee
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hub Mirror Action.
+        uses: Yikun/hub-mirror-action@v1.2
+        with:
+          src: github/xkinput
+          dst: gitee/xkinput
+          dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
+          static_list: "Rime_JD"
+          account_type: org


### PR DESCRIPTION
在合并之前需要做的事情：

1. 创建一个 SSH 公私密钥对
2. 在 [Gitee 设置页面](https://gitee.com/profile/sshkeys) 添加公钥
3. 在[本仓库设置页面](https://github.com/xkinput/Rime_JD/settings) 把私钥添加到 Action 的 secrets 里，命名为 `GITEE_PRIVATE_KEY`

由于我只有本组织的 write 权限，没有 admin 权限，第三步无法做，应该需要 @reaink 来完成