### PR TITLE
自动更新 plum 分支

### DIFF
--- a/.github/workflows/plum.yml
+++ b/.github/workflows/plum.yml
@@ -1,0 +1,48 @@
+name: Sync for plum
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout plum branch
+        uses: actions/checkout@v3
+        with:
+          ref: 'plum'
+
+      - name: Checkout master branch to subdirectory
+        uses: actions/checkout@v3
+        with:
+          ref: 'master'
+          path: master
+
+      - name: Copy files
+        run: |
+          cp master/rime/xkjd6.*.yaml ./
+          cp master/rime/lua/date_time.lua ./lua/
+          cp master/rime/lua/xkjd6_filter.lua ./lua/
+          cp master/rime/opencc/EN* ./opencc/
+          cp master/rime/opencc/emoji*.json ./opencc/
+          cp master/rime/opencc/emoji*.ocd ./opencc/
+          cp master/rime/opencc/ST*.txt ./opencc/
+          cp master/rime/opencc/TWVariants.txt ./opencc/
+          cp master/rime/opencc/s2tw.json ./opencc/
+          cp master/Tools/SystemTools/rime/xkjd6.schema.yaml ./
+
+      - name: Remove redundancy files
+        run: |
+          rm xkjd6.wxwdanzi.dict.yaml
+          rm -rf master
+
+      - name: Commit and push
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
+            git push
+          fi


### PR DESCRIPTION
当 master 分支有更新的时候，自动更新到 plum 分支

我检查了一下，由于 `xkjd6.schema.yaml` 有差异，导致 plum 安装的最小配置的反查有点小问题，Mac 下的反查功能是最新的，没有同步到 `Tools/SystemTools/rime/xkjd6.schema.yaml`，我之后再改一下这个文件，把 Mac 下的反查同步过来。