### PR TITLE
（通用、Linux）去除 xkjd6cx 依赖，改为 bin 词典反查

### DIFF
--- a/Tools/SystemTools/rime/Linux/xkjd6.schema.yaml
+++ b/Tools/SystemTools/rime/Linux/xkjd6.schema.yaml
@@ -7,8 +7,19 @@ schema:
   version: "1"
   author:
     - 发明人 大牛
-  dependencies:
-    - xkjd6cx
+
+# Layout config
+layout:
+  algebra:
+    - derive/^[bcdefghjklmnpqrstwxyz;]([bcdefghjklmnpqrstwxyz;][avuio].*)$/`$1/
+    - derive/^([bcdefghjklmnpqrstwxyz;])[bcdefghjklmnpqrstwxyz;]([avuio].*)$/$1`$2/
+    - derive/^([bcdefghjklmnpqrstwxyz;`]{2})[avuio](.*)$/$1`$2/
+    - derive/^([bcdefghjklmnpqrstwxyz;`]{2}[avuio`]).(.*)$/$1`$2/
+    - derive/^([bcdefghjklmnpqrstwxyz;`]{2}[avuio`]{2}).(.*)$/$1`$2/
+    - derive/^([bcdefghjklmnpqrstwxyz;`]{2}[avuio`]{3}).(.*)$/$1`$2/
+    - derive/^([bcdefghjklmnpqrstwxyz;`]{2}[avuio`]{4}).(.*)$/$1`$2/
+    - derive/^([bcdefghjklmnpqrstwxyz;`]{2}[avuio`]{5}).$/$1`/
+    - derive/^[bcdefghjklmnpqrstwxyz;]{2}([avuio`]*)$/``$1/
 
 switches:
   - name: ascii_mode
@@ -27,7 +38,7 @@ switches:
   - name: topup_hint
     reset: 1
     states: [ "关顶功提示", "开顶功提示" ]
-    
+
 punctuator:
   full_shape:
     ' ' : { commit: '　' }
@@ -116,10 +127,9 @@ engine:
   translators:
     - punct_translator
     - table_translator@custom_phrase
-    # - reverse_lookup_translator
     - table_translator
-    - lua_translator@date_time_translator
     - history_translator@repeat_history
+    - lua_translator@date_time_translator
   filters:
     - simplifier
     - uniquifier
@@ -127,13 +137,15 @@ engine:
     - simplifier@jffh
     - simplifier@bmms
     - simplifier@EN2en
-    - reverse_lookup_translator
+    - reverse_lookup_filter@danzi_lookup
     - lua_filter@xkjd6_filter
 
 speller:
+  algebra:
+    __include: "layout/algebra"
   auto_select: true
-  alphabet: "zyxwvutsrqponmlkjihgfedcba;"
-  initials: "abcdefghijklmnopqrstuvwxyz;"
+  alphabet: "zyxwvutsrqponmlkjihgfedcba;`"
+  initials: "abcdefghijklmnopqrstuvwxyz;`"
 
 translator:
   dictionary: xkjd6.extended
@@ -170,18 +182,26 @@ bmms:
   comment_format:
     - xform/'/ /
 
+danzi_lookup:
+  dictionary: xkjd6.extended
+  tags: [ danzi_lookup ]
+  overwrite_comment: true
+  enable_charset_filter: false
+  enable_completion: true
+  enable_encoder: false
+  enable_sentence: false
+  enable_user_dict: false
+  encode_commit_history: false
+  comment_format:
+    - xform/^/〔/
+    - xform/$/〕/
+    - xform/ /, /
+
 custom_phrase:
   dictionary: ""
   user_dict: custom_phrase
   db_class: stabledb
   enable_sentence: false
-
-reverse_lookup:
-  dictionary: xkjd6cx
-  comment_format:
-    - xform/^/〔/
-    - xform/$/〕/
-    - xform/ /, /
 
 punctuator:
   import_preset: symbols
@@ -199,7 +219,6 @@ key_binder:
 recognizer:
   import_preset: default
   patterns:
-    reverse_lookup: "[a-z`]*`+[a-z`]*"
     english: "^'[A-Z|a-z]*'?$"
     danzi_lookup: "[a-z`]*`+[a-z`]*"
     punct: "^/([0-9]0?|[a-z]+)$"

--- a/Tools/SystemTools/rime/xkjd6.schema.yaml
+++ b/Tools/SystemTools/rime/xkjd6.schema.yaml
@@ -7,8 +7,19 @@ schema:
   version: "1"
   author:
     - 发明人 大牛
-  dependencies:
-    - xkjd6cx
+
+# Layout config
+layout:
+  algebra:
+    - derive/^[bcdefghjklmnpqrstwxyz;]([bcdefghjklmnpqrstwxyz;][avuio].*)$/`$1/
+    - derive/^([bcdefghjklmnpqrstwxyz;])[bcdefghjklmnpqrstwxyz;]([avuio].*)$/$1`$2/
+    - derive/^([bcdefghjklmnpqrstwxyz;`]{2})[avuio](.*)$/$1`$2/
+    - derive/^([bcdefghjklmnpqrstwxyz;`]{2}[avuio`]).(.*)$/$1`$2/
+    - derive/^([bcdefghjklmnpqrstwxyz;`]{2}[avuio`]{2}).(.*)$/$1`$2/
+    - derive/^([bcdefghjklmnpqrstwxyz;`]{2}[avuio`]{3}).(.*)$/$1`$2/
+    - derive/^([bcdefghjklmnpqrstwxyz;`]{2}[avuio`]{4}).(.*)$/$1`$2/
+    - derive/^([bcdefghjklmnpqrstwxyz;`]{2}[avuio`]{5}).$/$1`/
+    - derive/^[bcdefghjklmnpqrstwxyz;]{2}([avuio`]*)$/``$1/
 
 switches:
   - name: ascii_mode
@@ -27,7 +38,7 @@ switches:
   - name: topup_hint
     reset: 1
     states: [ "关顶功提示", "开顶功提示" ]
-    
+
 punctuator:
   full_shape:
     ' ' : { commit: '　' }
@@ -116,10 +127,8 @@ engine:
   translators:
     - punct_translator
     - table_translator@custom_phrase
-    - reverse_lookup_translator
     - table_translator
     - history_translator@repeat_history
-    - lua_translator@Lunar_calendar_translator
     - lua_translator@date_time_translator
   filters:
     - simplifier
@@ -128,13 +137,15 @@ engine:
     - simplifier@jffh
     - simplifier@bmms
     - simplifier@EN2en
-    - reverse_lookup_translator
+    - reverse_lookup_filter@danzi_lookup
     - lua_filter@xkjd6_filter
 
 speller:
+  algebra:
+    __include: "layout/algebra"
   auto_select: true
-  alphabet: "zyxwvutsrqponmlkjihgfedcba;"
-  initials: "abcdefghijklmnopqrstuvwxyz;"
+  alphabet: "zyxwvutsrqponmlkjihgfedcba;`"
+  initials: "abcdefghijklmnopqrstuvwxyz;`"
 
 translator:
   dictionary: xkjd6.extended
@@ -171,18 +182,26 @@ bmms:
   comment_format:
     - xform/'/ /
 
+danzi_lookup:
+  dictionary: xkjd6.extended
+  tags: [ danzi_lookup ]
+  overwrite_comment: true
+  enable_charset_filter: false
+  enable_completion: true
+  enable_encoder: false
+  enable_sentence: false
+  enable_user_dict: false
+  encode_commit_history: false
+  comment_format:
+    - xform/^/〔/
+    - xform/$/〕/
+    - xform/ /, /
+
 custom_phrase:
   dictionary: ""
   user_dict: custom_phrase
   db_class: stabledb
   enable_sentence: false
-
-reverse_lookup:
-  dictionary: xkjd6cx
-  comment_format:
-    - xform/^/〔/
-    - xform/$/〕/
-    - xform/ /, /
 
 punctuator:
   import_preset: symbols
@@ -200,7 +219,6 @@ key_binder:
 recognizer:
   import_preset: default
   patterns:
-    reverse_lookup: "[a-z`]*`+[a-z`]*"
     english: "^'[A-Z|a-z]*'?$"
     danzi_lookup: "[a-z`]*`+[a-z`]*"
     punct: "^/([0-9]0?|[a-z]+)$"


### PR DESCRIPTION
## 改动

### 通用配置 `Tools/SystemTools/rime/xkjd6.schema.yaml`

#### 使用自身词库反查
1. 去除 xkjd6cx 依赖
2. 添加了反查用的代数 (`layout/algebra`) 
3. 在 `speller/algebra` 中引用反查代数
4. `engine/translators` 删除旧的反查翻译器
5. `engine/filters` 添加新的反查过滤器 `danzi_lookup`
6. `speller` 字母表中添加反查用的反撇 `` ` ``
7. 添加反查过滤器 `danzi_lookup` 具体定义
8. 删除启用的反查翻译器 `reverse_lookup` 定义
9. `recognizer/patterns` 删除弃用的反查翻译器的模式

#### 其他改动
1. 删除多余空格
2. 删除 `Lunar_calendar_translator` 的引用（仓库里已经没有这个翻译器了）

### Linux 配置 `Tools/SystemTools/rime/Linux/xkjd6.schema.yaml`

几乎和通用配置的改动一样，改动后两个配置完全相同

## 以后可以改动的地方（这次没改动）

可以删除第一个 `punctuator` 定义，因为在后文重新定义了一遍：

```yaml
# 保留这个就行了
punctuator:
  import_preset: symbols
```