### PR TITLE
feat: 顶功提示自定义字符

### DIFF
--- a/rime/lua/xkjd6_filter.lua
+++ b/rime/lua/xkjd6_filter.lua
@@ -26,8 +26,8 @@ local function danzi(cand)
     return false
 end
 
-local function commit_hint(cand)
-    cand:get_genuine().comment = '🚫' .. cand.comment
+local function commit_hint(cand, hint_text)
+    cand:get_genuine().comment = hint_text .. cand.comment
 end
 
 local function filter(input, env)
@@ -35,12 +35,13 @@ local function filter(input, env)
     local is_on = env.engine.context:get_option('sbb_hint')
     local disable_full = env.engine.context:get_option('sbb_disable_full')
     local topup_hint_on = env.engine.context:get_option('topup_hint')
+    local hint_text = env.engine.schema.config:get_string('hint_text') or '🚫'
     local first = true
     local input_text = env.engine.context.input
     local no_commit = topup_hint_on and input_text:len() < 4 and input_text:match("^[bcdefghjklmnpqrstwxyz]+$")
     for cand in input:iter() do
         if first and no_commit and cand.type ~= 'completion' then
-            commit_hint(cand)
+            commit_hint(cand, hint_text)
         end
         first = false
         if not is_danzi or danzi(cand) then


### PR DESCRIPTION
使用方法：在 xkjd6.custom.yaml 的 patch 下，添加
```yaml
patch:
  hint_text: '哒咩'
```

效果：
![图片](https://github.com/xkinput/Rime_JD/assets/523025/7e0c42c7-7505-4732-b3c8-0144d117202c)

设置成空字符串甚至可以关闭提示，完全取代 `topup_hint` 开关