### PR TITLE
fix #39: 「噷」「呒」「呣」三字编码

### DIFF
--- a/Tools/TermsTools/danzi.txt
+++ b/Tools/TermsTools/danzi.txt
@@ -3060,7 +3060,6 @@
 府	fjoviv
 呋	fjovv
 呋	fjovvu
-呒	fjovvu
 复	fju
 负	fjua
 负	fjuaao
@@ -5128,6 +5127,8 @@
 慌	hmooii
 恍	hmooio
 惶	hmooui
+噷	hmoov
+噷	hmoovo
 煌	hmou
 喤	hmoui
 喤	hmouia
@@ -9109,8 +9110,6 @@
 拇	mjiuaa
 仫	mjiuao
 亩	mjo
-呣	mjoa
-呣	mjoaao
 𧿹	mjoi
 𧿹	mjoiaa
 亩	mjovia
@@ -13448,7 +13447,6 @@
 庑	wjovv
 痦	wjovvi
 吴	wjovvu
-呒	wjovvu
 庑	wjovvv
 物	wju
 务	wjua
@@ -14977,6 +14975,7 @@
 诜	xmoa
 禒	xmoaa
 禒	xmoaaa
+呣	xmoaao
 诜	xmoauv
 祆	xmoav
 祆	xmoavv
@@ -15005,6 +15004,8 @@
 痫	xmovoi
 冼	xmovu
 冼	xmovuv
+呒	xmovv
+呒	xmovvu
 鲜	xmu
 馅	xmua
 猃	xmuai

--- a/Tools/TermsTools/xkjd6.danzi.dict.yaml
+++ b/Tools/TermsTools/xkjd6.danzi.dict.yaml
@@ -3065,7 +3065,6 @@ sort: original
 府	fjoviv
 呋	fjovv
 呋	fjovvu
-呒	fjovvu
 复	fju
 负	fjua
 负	fjuaao
@@ -5133,6 +5132,8 @@ sort: original
 慌	hmooii
 恍	hmooio
 惶	hmooui
+噷	hmoov
+噷	hmoovo
 煌	hmou
 喤	hmoui
 喤	hmouia
@@ -9114,8 +9115,6 @@ sort: original
 拇	mjiuaa
 仫	mjiuao
 亩	mjo
-呣	mjoa
-呣	mjoaao
 𧿹	mjoi
 𧿹	mjoiaa
 亩	mjovia
@@ -13453,7 +13452,6 @@ sort: original
 庑	wjovv
 痦	wjovvi
 吴	wjovvu
-呒	wjovvu
 庑	wjovvv
 物	wju
 务	wjua
@@ -14982,6 +14980,7 @@ sort: original
 诜	xmoa
 禒	xmoaa
 禒	xmoaaa
+呣	xmoaao
 诜	xmoauv
 祆	xmoav
 祆	xmoavv
@@ -15010,6 +15009,8 @@ sort: original
 痫	xmovoi
 冼	xmovu
 冼	xmovuv
+呒	xmovv
+呒	xmovvu
 鲜	xmu
 馅	xmua
 猃	xmuai

--- a/rime/xkjd6.danzi.dict.yaml
+++ b/rime/xkjd6.danzi.dict.yaml
@@ -3065,7 +3065,6 @@ sort: original
 府	fjoviv
 呋	fjovv
 呋	fjovvu
-呒	fjovvu
 复	fju
 负	fjua
 负	fjuaao
@@ -5133,6 +5132,8 @@ sort: original
 慌	hmooii
 恍	hmooio
 惶	hmooui
+噷	hmoov
+噷	hmoovo
 煌	hmou
 喤	hmoui
 喤	hmouia
@@ -9114,8 +9115,6 @@ sort: original
 拇	mjiuaa
 仫	mjiuao
 亩	mjo
-呣	mjoa
-呣	mjoaao
 𧿹	mjoi
 𧿹	mjoiaa
 亩	mjovia
@@ -13453,7 +13452,6 @@ sort: original
 庑	wjovv
 痦	wjovvi
 吴	wjovvu
-呒	wjovvu
 庑	wjovvv
 物	wju
 务	wjua
@@ -14982,6 +14980,7 @@ sort: original
 诜	xmoa
 禒	xmoaa
 禒	xmoaaa
+呣	xmoaao
 诜	xmoauv
 祆	xmoav
 祆	xmoavv
@@ -15010,6 +15009,8 @@ sort: original
 痫	xmovoi
 冼	xmovu
 冼	xmovuv
+呒	xmovv
+呒	xmovvu
 鲜	xmu
 馅	xmua
 猃	xmuai


### PR DESCRIPTION
根据QQ群里的讨论，多数人不反对把空韵当作特殊的拼音，为了最大化兼容现有编码，为特殊的拼音安排了合适的编码：

其中：
1. 特殊的韵母 ê：按键 w，零声母编码为 xw（兼容已有单字「诶」「欸」）
2. 空韵拼音 m：按键 m，当作特殊韵母，零声母编码为 xm
3. 空韵拼音 n：按键 n，当作特殊韵母，零声母编码为 xn（兼容已有单字「嗯」「唔」）
4. 空韵拼音 ng：按键 r，当作特殊韵母，零声母编码为 xr（兼容已有单字「嗯」「唔」）
5. 空韵拼音 hng：当作声母 h + 特殊韵母 ng，与第四条自洽，编码为 hr（兼容已有单字「哼」）
6. 空韵拼音 hm：当作声母 h + 特殊韵母 m，与第二条和第五条自洽，编码为 hm