### PR TITLE
fix #47: 修正「亟」形码

### DIFF
--- a/Tools/TermsTools/danzi.txt
+++ b/Tools/TermsTools/danzi.txt
@@ -6189,8 +6189,8 @@
 际	jkai
 瀱	jkaia
 瀱	jkaiai
-亟	jkaii
-亟	jkaiia
+亟	jkaio
+亟	jkaioa
 际	jkaivv
 济	jkao
 鸡	jkaou
@@ -11029,7 +11029,7 @@
 绮	qkaavu
 骑	qkaavu
 亟	qkai
-亟	qkaiia
+亟	qkaioa
 泣	qkao
 泣	qkaovo
 汔	qkau

--- a/Tools/TermsTools/xkjd6.danzi.dict.yaml
+++ b/Tools/TermsTools/xkjd6.danzi.dict.yaml
@@ -6194,8 +6194,8 @@ sort: original
 际	jkai
 瀱	jkaia
 瀱	jkaiai
-亟	jkaii
-亟	jkaiia
+亟	jkaio
+亟	jkaioa
 际	jkaivv
 济	jkao
 鸡	jkaou
@@ -11034,7 +11034,7 @@ sort: original
 绮	qkaavu
 骑	qkaavu
 亟	qkai
-亟	qkaiia
+亟	qkaioa
 泣	qkao
 泣	qkaovo
 汔	qkau

--- a/rime/xkjd6.chaojizici.dict.yaml
+++ b/rime/xkjd6.chaojizici.dict.yaml
@@ -122,7 +122,6 @@ sort: original
 𫔎	jhioao
 𬺓	jjiv
 𬺓	jjivvv
-𬯀	jkaio
 𬯀	jkaiov
 𬶨	jkavua
 𫓯	jkiov

--- a/rime/xkjd6.danzi.dict.yaml
+++ b/rime/xkjd6.danzi.dict.yaml
@@ -6194,8 +6194,8 @@ sort: original
 际	jkai
 瀱	jkaia
 瀱	jkaiai
-亟	jkaii
-亟	jkaiia
+亟	jkaio
+亟	jkaioa
 际	jkaivv
 济	jkao
 鸡	jkaou
@@ -11034,7 +11034,7 @@ sort: original
 绮	qkaavu
 骑	qkaavu
 亟	qkai
-亟	qkaiia
+亟	qkaioa
 泣	qkao
 泣	qkaovo
 汔	qkau


### PR DESCRIPTION
「𬯀」在 chaojizici 里，删除其五码给「亟」让位