### PR TITLE
chore: 删除无用的 bmms

### DIFF
--- a/Tools/SystemTools/rime/Android/xkjd6.schema.yaml
+++ b/Tools/SystemTools/rime/Android/xkjd6.schema.yaml
@@ -166,7 +166,6 @@ engine:
     - uniquifier
     - simplifier@emoji_cn
     - simplifier@simplification
-    - simplifier@bmms
     - simplifier@EN2en
     - lua_filter@xkjd6_filter
     - reverse_lookup_filter@danzi_lookup
@@ -212,15 +211,6 @@ simplification:
   opencc_config: s2tw.json
   option_name: simplification
 
-
-bmms:
-  opencc_config: pinyin.json
-  option_name: bmms
-  show_in_comment: true
-  comment_format:
-    - xform/'/ /
-
-
 custom_phrase:
   dictionary: ""
   user_dict: user_dict
@@ -251,7 +241,6 @@ key_binder:
     - {accept: equal, send: Page_Down, when: has_menu}
     # - { when: has_menu, accept: "'", send: 2 }
     - { when: has_menu, accept: "&", toggle: emoji_cn}
-    - { when: has_menu, accept: "^", toggle: bmms}
 
 
 recognizer:

--- a/Tools/SystemTools/rime/Linux/xkjd6.schema.yaml
+++ b/Tools/SystemTools/rime/Linux/xkjd6.schema.yaml
@@ -145,7 +145,6 @@ engine:
     - uniquifier
     - simplifier@emoji_cn
     - simplifier@jffh
-    - simplifier@bmms
     - simplifier@EN2en
     - reverse_lookup_filter@danzi_lookup
     - lua_filter@xkjd6_filter
@@ -185,13 +184,6 @@ jffh:
   opencc_config: s2tw.json
   option_name: jffh
 
-bmms:
-  opencc_config: pinyin.json
-  option_name: bmms
-  show_in_comment: true
-  comment_format:
-    - xform/'/ /
-
 danzi_lookup:
   dictionary: xkjd6.extended
   tags: [ danzi_lookup ]
@@ -224,7 +216,6 @@ key_binder:
     - { when: always, accept: F7, toggle: jffh }
     - { when: has_menu, accept: "'", send: 2 }
     - { when: has_menu, accept: "&", toggle: emoji_cn}
-    - { when: has_menu, accept: "^", toggle: bmms}
 
 recognizer:
   import_preset: default

--- a/Tools/SystemTools/rime/Mac/xkjd6.schema.yaml
+++ b/Tools/SystemTools/rime/Mac/xkjd6.schema.yaml
@@ -1,4 +1,4 @@
-﻿# Rime schema settings
+# Rime schema settings
 # encoding: utf-8
 
 schema:
@@ -161,7 +161,6 @@ engine:
   filters:
     - simplifier@emoji_cn
     - simplifier@jffh
-    - simplifier@bmms
     - simplifier@EN2en
     - uniquifier
     - reverse_lookup_filter@danzi_lookup
@@ -208,15 +207,6 @@ jffh:
   opencc_config: s2t.json
   option_name: jffh
 
-
-bmms:
-  opencc_config: pinyin.json
-  option_name: bmms
-  show_in_comment: true
-  comment_format:
-    - "xform/'/ /"
-
-
 danzi_lookup:
   dictionary: xkjd6.extended
   tags: [ danzi_lookup ]
@@ -248,7 +238,6 @@ key_binder:
     - { when: always, accept: F7, toggle: jffh }
     # - { when: has_menu, accept: "'", send: 2 }
     - { when: has_menu, accept: "&", toggle: emoji_cn}
-    - { when: has_menu, accept: "^", toggle: bmms}
 
 
 recognizer:

--- a/Tools/SystemTools/rime/Windows/xkjd6.schema.yaml
+++ b/Tools/SystemTools/rime/Windows/xkjd6.schema.yaml
@@ -1,4 +1,4 @@
-﻿# Rime schema settings
+# Rime schema settings
 # encoding: utf-8
 
 schema:
@@ -160,7 +160,6 @@ engine:
     - uniquifier
     - simplifier@emoji_cn
     - simplifier@jffh
-    - simplifier@bmms
     - simplifier@EN2en
     # - lua_filter@hint_filter
     - lua_filter@xkjd6_filter
@@ -208,15 +207,6 @@ EN2en:
   opencc_config: EN2en.json
   option_name: EN2en
 
-
-bmms:
-  opencc_config: pinyin.json
-  option_name: bmms
-  show_in_comment: true
-  comment_format:
-    - xform/'/ /
-
-
 danzi_lookup:
   dictionary: xkjd6.extended
   tags: [ danzi_lookup ]
@@ -255,7 +245,6 @@ key_binder:
     - { when: always, accept: F7, toggle: jffh }
     # - { when: has_menu, accept: "'", send: 2 }
     - { when: has_menu, accept: "&", toggle: emoji_cn}
-    - { when: has_menu, accept: "^", toggle: bmms}
 
 
 recognizer:

--- a/Tools/SystemTools/rime/xkjd6.schema.yaml
+++ b/Tools/SystemTools/rime/xkjd6.schema.yaml
@@ -1,4 +1,4 @@
-﻿# Rime schema settings
+# Rime schema settings
 # encoding: utf-8
 
 schema:
@@ -145,7 +145,6 @@ engine:
     - uniquifier
     - simplifier@emoji_cn
     - simplifier@jffh
-    - simplifier@bmms
     - simplifier@EN2en
     - reverse_lookup_filter@danzi_lookup
     - lua_filter@xkjd6_filter
@@ -185,13 +184,6 @@ jffh:
   opencc_config: s2tw.json
   option_name: jffh
 
-bmms:
-  opencc_config: pinyin.json
-  option_name: bmms
-  show_in_comment: true
-  comment_format:
-    - xform/'/ /
-
 danzi_lookup:
   dictionary: xkjd6.extended
   tags: [ danzi_lookup ]
@@ -224,7 +216,6 @@ key_binder:
     - { when: always, accept: F7, toggle: jffh }
     - { when: has_menu, accept: "'", send: 2 }
     - { when: has_menu, accept: "&", toggle: emoji_cn}
-    - { when: has_menu, accept: "^", toggle: bmms}
 
 recognizer:
   import_preset: default


### PR DESCRIPTION
`bmms` 选项没有作用，没有任何地方能找到这个需要的 pinyin.json 和相应的转换表。