### PR TITLE
fix: update installation instructions for Nix to use desktop schemas for all platforms

### DIFF
--- a/INSTALL_NIXOS.md
+++ b/INSTALL_NIXOS.md
@@ -7,13 +7,10 @@
 Nix 包会自动根据系统平台安装以下文件到 Rime 数据目录：
 
 - **主码表文件**：`rime/` 目录下的所有词库和配置
-- **Linux 专用配置**：
-  - `schema/linux/keytao.schema.yaml` - Linux 版键道6方案
-  - `schema/linux/keytao-dz.schema.yaml` - Linux 版键道6单字方案
-- **macOS 专用配置**：
-  - `schema/mac/keytao.schema.yaml` - Mac 版键道6方案
-  - `schema/mac/keytao-dz.schema.yaml` - Mac 版键道6单字方案
-  - `schema/mac/default.custom.yaml` - 默认配置
+- **桌面通用方案**（Linux / macOS / Windows 共用）：
+  - `schema/desktop/keytao.schema.yaml` - 键道6方案
+  - `schema/desktop/keytao-dz.schema.yaml` - 键道6单字方案
+- **macOS 专用配置**（覆盖通用方案）：
   - `schema/mac/squirrel.custom.yaml` - 鼠须管配置
   - 自动部署到 `~/Library/Rime` 目录（鼠须管默认目录）
 

--- a/default.nix
+++ b/default.nix
@@ -22,13 +22,14 @@ stdenvNoCC.mkDerivation rec {
     ${
       if stdenvNoCC.isDarwin then
         ''
-          # macOS: Install Mac-specific configs
+          # macOS: Install desktop schema, then overlay Mac-specific configs
+          cp schema/desktop/*.yaml $out/share/rime-data/
           cp schema/mac/*.yaml $out/share/rime-data/
         ''
       else
         ''
-          # Linux: Install Linux-specific schemas
-          cp schema/linux/*.yaml $out/share/rime-data/
+          # Linux: Install desktop schema
+          cp schema/desktop/*.yaml $out/share/rime-data/
         ''
     }
 


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>